### PR TITLE
Fix wrong line break in citations with firefox

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -151,7 +151,7 @@ div.panel {
 	display: inline-block;
 	margin: 0px;
 	line-height: 1.4em;
-
+	width: -moz-available;
 	padding-left: 0;
 	text-indent: 0;
 }


### PR DESCRIPTION
Add a CSS property for Firefox only to fix there
the width of the div's of the classes
`inline-csl-entry` and `bibliography-csl-entry`.
This prevents Firefox to break the line wrongly
inside the citation examples in the visual editor.

This fixes #161