### PR TITLE
Update searchByExample.html

### DIFF
--- a/html/searchByExample.html
+++ b/html/searchByExample.html
@@ -1,9 +1,9 @@
 
 <div id=leftColumn>
 	<div class=padding>
-		<h2><strong>1.</strong> Using the details below...</h2>
+		<h2><strong>1.</strong> Select an item below…</h2>
 		<div id=exampleDocumentContainer>
-			<h3>Example Reference</h3>
+			<h3>Cited Item</h3>
 			<button id="prevExample">Previous</button>
 			<button id="nextExample">&nbsp;&nbsp;Next&nbsp;&nbsp;</button>
 			<div id=exampleDocument>
@@ -15,15 +15,15 @@
 <div id=rightColumn>
 	<div class=padding>
 		<div id=styleFormatInputControls class="topPaneHeight">
-			<h2><strong>2.</strong> Type a citation in the style you require</h2>
+			<h2><strong>2.</strong> Change the in-text citation and bibliographic entry for this item to the desired format…</h2>
 			<div>
-				<h3>Inline Citation</h3>
+				<h3>In-text Citation</h3>
 				<div id=citationContainer>
 					<div class=arrow></div>
 					<div id="userCitation" placeholder="Type inline citation here" ></div>
 				</div>
 				<br />
-				<h3>Bibliography</h3>
+				<h3>Bibliographic Entry</h3>
 				<div id=bibliographyContainer>
 					<div class=arrow></div>
 					<div id="userBibliography" placeholder="Type bibliography entry here" ></div>
@@ -42,7 +42,7 @@
 
 <div id="resultsPane">
 	<div class="padding">
-	<h2><strong>3.</strong> And we'll show you the closest matches.</h2>
+	<h2><strong>3.</strong> Click "Search", and we'll show you the closest matches.</h2>
 	<div id=searchResults></div>
 	</div>
 </div>


### PR DESCRIPTION
I tried to clarify the instructions for the searchByExample tool. From the Zotero forums, it appears that users commonly try to paste in any given citation or bibliographic entry, which doesn't work. Hopefully the new instructions are a little clearer.

I renamed "Inline citation" and "Bibliography" to "In-text citation" and "Bibliographic Entry", which is consistent with what I use in the CSL spec. If we're okay with that, we need to make this change throughout the CSL editor (there are a bunch of places where these terms are used).