### PR TITLE
Put xmlns attribute first

### DIFF
--- a/src/schemaOptions.js
+++ b/src/schemaOptions.js
@@ -31,6 +31,19 @@ define({
 			}],
 			alwaysOutput : true
 		};
+		
+		// put xmlns attribute first
+		var tempStyleAttributes = JSON.parse(JSON.stringify(nodeProperties["root/style"].attributes));
+		for (var styleAttribute in nodeProperties["root/style"].attributes){
+			if (nodeProperties["root/style"].attributes.hasOwnProperty(styleAttribute) && styleAttribute !== "xmlns"){
+				delete nodeProperties["root/style"].attributes[styleAttribute];
+			}
+		}
+		for (styleAttribute in tempStyleAttributes){
+			if (tempStyleAttributes.hasOwnProperty(styleAttribute) && styleAttribute !== "xmlns"){
+				nodeProperties["root/style"].attributes[styleAttribute] = tempStyleAttributes[styleAttribute];
+			}
+		}
 
 		nodeProperties["root/style"].attributes["version"].alwaysOutput = true;
 


### PR DESCRIPTION
I know that JavaScript object attributes officially don’t have an order, but I prefer to keep the xmlns attribute at the start of the style element, and this code works for me (in Chrome).

See https://github.com/citation-style-language/styles/commit/33ab94fe27856d8f14a8bcd0bbd02ca5a1ea389c#diff-6a52dc4de6b126dc7e28e0902fe7f752 for an example of where we reorder this attribute with my Python script.

I got it to work by deep-cloning the object (http://stackoverflow.com/a/4591639/1712389), deleting all attributes except xmlns (http://stackoverflow.com/questions/19316857/removing-all-properties-from-a-object), and then repopulating the object with the deleted attributes.