### PR TITLE
Fix direction of next/previous buttons

### DIFF
--- a/src/SearchByExample.js
+++ b/src/SearchByExample.js
@@ -462,10 +462,10 @@ define(
 			updateExample(0, true);
 
 			$('#nextExample').click(function () {
-				updateExample(exampleIndex - 1);
+				updateExample(exampleIndex + 1);
 			});
 			$('#prevExample').click(function () {
-				updateExample(exampleIndex + 1);
+				updateExample(exampleIndex - 1);
 			});
 
 			setSelectedControl("citation");


### PR DESCRIPTION
@adam3smith, I noticed that while I put the Mares second in the metadata file (https://github.com/citation-style-language/csl-editor/pull/199), I had to click the "Previous" button to select it at http://editor.citationstyles.org/searchByExample/ (the Campbell & Pedersen is the default selected item).

Turns out the next/previous button direction was switched around.